### PR TITLE
Don't inject empty name fields into portDefinitions.

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -20,7 +20,7 @@ type marathonGroup struct {
 
 type portDefinition struct {
 	Port int64  `json:"port" yaml:"port"`
-	Name string `json:"name" yaml:"name"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 type checkCommand struct {

--- a/marathon_test.go
+++ b/marathon_test.go
@@ -106,6 +106,10 @@ func TestMarathonParseYAMLPorts(t *testing.T) {
 			validateFunc: func(g *marathonGroup) bool { return g.Apps[0].PortDefinitions[0].Name == "metrics" },
 		},
 		{
+			yaml:         "apps: [{portDefinitions: [{port: 0}, {port: 0, name: pprof}]}]",
+			validateFunc: func(g *marathonGroup) bool { return g.Apps[0].PortDefinitions[0].Name == "" && g.Apps[0].PortDefinitions[1].Name == "pprof" },
+		},
+		{
 			yaml:         "apps: [{portDefinitions: [0, 0]}]",
 			expectError:  true,
 			validateFunc: nil,
@@ -137,6 +141,11 @@ func TestMarathonYAMLtoJSON(t *testing.T) {
 		{
 			yaml: []byte(`apps: [{ports: [0, 0]}]`),
 			json: []byte(`{"id":"","apps":[{"id":"","instances":0,"cpus":0,"mem":0,"constraints":null,"ports":[0,0],"requirePorts":false,"container":{"type":"","volumes":null}}]}`),
+		},
+		// validate that portDefinition doesn't create empty name fields.
+		{
+			yaml: []byte(`apps: [{portDefinitions: [{port: 0}]}]`),
+			json: []byte(`{"id":"","apps":[{"id":"","instances":0,"cpus":0,"mem":0,"constraints":null,"portDefinitions":[{"port":0}],"requirePorts":false,"container":{"type":"","volumes":null}}]}`),
 		},
 		{
 			yaml: []byte(`apps: [{portDefinitions: [{port: 0, name: metrics}, {port: 0, name: pprof}]}]`),

--- a/marathon_test.go
+++ b/marathon_test.go
@@ -106,8 +106,10 @@ func TestMarathonParseYAMLPorts(t *testing.T) {
 			validateFunc: func(g *marathonGroup) bool { return g.Apps[0].PortDefinitions[0].Name == "metrics" },
 		},
 		{
-			yaml:         "apps: [{portDefinitions: [{port: 0}, {port: 0, name: pprof}]}]",
-			validateFunc: func(g *marathonGroup) bool { return g.Apps[0].PortDefinitions[0].Name == "" && g.Apps[0].PortDefinitions[1].Name == "pprof" },
+			yaml: "apps: [{portDefinitions: [{port: 0}, {port: 0, name: pprof}]}]",
+			validateFunc: func(g *marathonGroup) bool {
+				return g.Apps[0].PortDefinitions[0].Name == "" && g.Apps[0].PortDefinitions[1].Name == "pprof"
+			},
 		},
 		{
 			yaml:         "apps: [{portDefinitions: [0, 0]}]",


### PR DESCRIPTION
Cfdeploy wasn't handling this snippet correctly:
```
portDefinitions:
  - port: 0
```

Specifically, it was converting this to:
```
portDefintions:
  - port: 0
    name: ""
```
Which isn't valid.  Thus mark that field as optional, since it is.