### PR TITLE
I made command structure optional to generate valid JSON for HTTP hea…

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -73,14 +73,14 @@ type marathonApp struct {
 	Labels       map[string]string `json:"labels,omitempty" yaml:"labels"`
 	Dependencies []string          `json:"dependencies,omitempty" yaml:"dependencies"`
 	HealthChecks []struct {
-		Protocol               string       `json:"protocol,omitempty" yaml:"protocol"`
-		Command                checkCommand `json:"command,omitempty" yaml:"command"`
-		Path                   string       `json:"path,omitempty" yaml:"path"`
-		GracePeriodSeconds     int64        `json:"gracePeriodSeconds,omitempty" yaml:"gracePeriodSeconds"`
-		IntervalSeconds        int64        `json:"intervalSeconds,omitempty" yaml:"intervalSeconds"`
-		PortIndex              int64        `json:"portIndex,omitempty" yaml:"portIndex"`
-		TimeoutSeconds         int64        `json:"timeoutSeconds,omitempty" yaml:"timeoutSeconds"`
-		MaxConsecutiveFailures int64        `json:"maxConsecutiveFailures,omitempty" yaml:"maxConsecutiveFailures"`
+		Protocol               string        `json:"protocol,omitempty" yaml:"protocol"`
+		Command                *checkCommand `json:"command,omitempty" yaml:"command"`
+		Path                   string        `json:"path,omitempty" yaml:"path"`
+		GracePeriodSeconds     int64         `json:"gracePeriodSeconds,omitempty" yaml:"gracePeriodSeconds"`
+		IntervalSeconds        int64         `json:"intervalSeconds,omitempty" yaml:"intervalSeconds"`
+		PortIndex              int64         `json:"portIndex,omitempty" yaml:"portIndex"`
+		TimeoutSeconds         int64         `json:"timeoutSeconds,omitempty" yaml:"timeoutSeconds"`
+		MaxConsecutiveFailures int64         `json:"maxConsecutiveFailures,omitempty" yaml:"maxConsecutiveFailures"`
 	} `json:"healthChecks,omitempty" yaml:"healthChecks"`
 	UpgradeStrategy *struct {
 		MinimumHealthCapacity *float64 `json:"minimumHealthCapacity,omitempty" yaml:"minimumHealthCapacity"`

--- a/marathon_test.go
+++ b/marathon_test.go
@@ -157,6 +157,10 @@ func TestMarathonYAMLtoJSON(t *testing.T) {
 			yaml: []byte(`apps: [{healthChecks: [{protocol: COMMAND, command: {value: foo}, gracePeriodSeconds: 2, intervalSeconds: 2, portIndex: 1, timeoutSeconds: 2, maxConsecutiveFailures: 2 }]}]`),
 			json: []byte(`{"id":"","apps":[{"id":"","instances":0,"cpus":0,"mem":0,"constraints":null,"requirePorts":false,"container":{"type":"","volumes":null},"healthChecks":[{"protocol":"COMMAND","command":{"value":"foo"},"gracePeriodSeconds":2,"intervalSeconds":2,"portIndex":1,"timeoutSeconds":2,"maxConsecutiveFailures":2}]}]}`),
 		},
+		{
+			yaml: []byte(`apps: [{healthChecks: [{protocol: HTTP, gracePeriodSeconds: 2, intervalSeconds: 2, portIndex: 1, timeoutSeconds: 2, maxConsecutiveFailures: 2 }]}]`),
+			json: []byte(`{"id":"","apps":[{"id":"","instances":0,"cpus":0,"mem":0,"constraints":null,"requirePorts":false,"container":{"type":"","volumes":null},"healthChecks":[{"protocol":"HTTP","gracePeriodSeconds":2,"intervalSeconds":2,"portIndex":1,"timeoutSeconds":2,"maxConsecutiveFailures":2}]}]}`),
+		},
 	}
 	for i, test := range tests {
 		config, err := marathonParseYAML(test.yaml)


### PR DESCRIPTION
Hello!

Right now cfdeploy generates incorrect JSON for HTTP health checks.

For this healthcheck in YAML:
```
    healthChecks:
      - protocol: HTTP
        path: /metrics
        portIndex: 0
        gracePeriodSeconds: 10
        intervalSeconds: 10
        timeoutSeconds: 30
        maxConsecutiveFailures: 3
```

It generates following JSON:
```
"healthChecks": [
{
"protocol": "HTTP",
"command": {
    "value": ""
},
"path": "/metrics",
"gracePeriodSeconds": 10,
"intervalSeconds": 10,
"timeoutSeconds": 30,
"maxConsecutiveFailures": 3
}
],
```

And Marathon rejects this JSON as invalid.

And I fixed it and added tests.

Thank you!